### PR TITLE
Add foreground scanning service and runtime permission handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
     <application
         android:allowBackup="false"
@@ -22,5 +23,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".sensing.ScanningService"
+            android:exported="false"
+            android:foregroundServiceType="location" />
     </application>
 </manifest>

--- a/app/src/main/java/com/vanta/phantomscout/sensing/ScanningService.kt
+++ b/app/src/main/java/com/vanta/phantomscout/sensing/ScanningService.kt
@@ -1,0 +1,65 @@
+package com.vanta.phantomscout.sensing
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.vanta.phantomscout.sensing.ble.BleScanner
+import com.vanta.phantomscout.sensing.wifi.WifiScanner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+/** Foreground service that runs Wi-Fi and BLE scanners. */
+class ScanningService : Service() {
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private lateinit var wifi: WifiScanner
+    private lateinit var ble: BleScanner
+
+    override fun onCreate() {
+        super.onCreate()
+        wifi = WifiScanner(this)
+        ble = BleScanner(this)
+        createChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(NOTIF_ID, buildNotification())
+        scope.launch { wifi.scanFlow().collect() }
+        scope.launch { ble.scanFlow().collect() }
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createChannel() {
+        val mgr = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(CHANNEL_ID, "Scanning", NotificationManager.IMPORTANCE_LOW)
+        mgr.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Scanning active")
+            .setContentText("Monitoring environment")
+            .setSmallIcon(android.R.drawable.ic_menu_search)
+            .build()
+
+    companion object {
+        private const val CHANNEL_ID = "scan"
+        private const val NOTIF_ID = 1
+    }
+}
+

--- a/app/src/main/java/com/vanta/phantomscout/ui/HomeActivity.kt
+++ b/app/src/main/java/com/vanta/phantomscout/ui/HomeActivity.kt
@@ -1,12 +1,54 @@
 package com.vanta.phantomscout.ui
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.widget.Button
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.vanta.phantomscout.R
+import com.vanta.phantomscout.sensing.ScanningService
 
-/** Simple host activity for fragments. */
+/** Simple host activity for fragments with scan controls. */
 class HomeActivity : AppCompatActivity() {
+    private val permissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Placeholder layout
+        setContentView(R.layout.activity_home)
+        ensurePermissions()
+
+        findViewById<Button>(R.id.btn_start).setOnClickListener {
+            ContextCompat.startForegroundService(
+                this,
+                Intent(this, ScanningService::class.java)
+            )
+        }
+        findViewById<Button>(R.id.btn_stop).setOnClickListener {
+            stopService(Intent(this, ScanningService::class.java))
+        }
+    }
+
+    private fun ensurePermissions() {
+        val perms = buildList {
+            add(Manifest.permission.ACCESS_FINE_LOCATION)
+            add(Manifest.permission.BLUETOOTH_SCAN)
+            add(Manifest.permission.BLUETOOTH_CONNECT)
+            if (Build.VERSION.SDK_INT >= 33) {
+                add(Manifest.permission.NEARBY_WIFI_DEVICES)
+                add(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+        val missing = perms.filter {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (missing.isNotEmpty()) {
+            permissionLauncher.launch(missing.toTypedArray())
+        }
     }
 }
+

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -1,5 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/container"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/btn_start"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Start" />
+
+        <Button
+            android:id="@+id/btn_stop"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Stop" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- Add `ScanningService` foreground service that runs Wi-Fi and BLE scans
- Request runtime permissions and add start/stop buttons in `HomeActivity`
- Register service and required permissions in `AndroidManifest`

## Testing
- `gradle test --no-daemon` *(fails: Plugin [id: 'com.android.application', version: '8.1.1', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10ad3d1348328ab6f0157c4da6568