### PR TITLE
Add telemetry, profiles, policies, and UI skeletons

### DIFF
--- a/app/src/main/assets/guardian_policies.json
+++ b/app/src/main/assets/guardian_policies.json
@@ -1,0 +1,4 @@
+[
+  {"name": "Default", "policy": "baseline"},
+  {"name": "Strict", "policy": "all_radio_off"}
+]

--- a/app/src/main/java/com/vanta/phantomscout/advisory/FixActions.kt
+++ b/app/src/main/java/com/vanta/phantomscout/advisory/FixActions.kt
@@ -1,0 +1,4 @@
+package com.vanta.phantomscout.advisory
+
+/** Action to remediate a detected risk. */
+data class FixAction(val message: String)

--- a/app/src/main/java/com/vanta/phantomscout/advisory/RulesEngine.kt
+++ b/app/src/main/java/com/vanta/phantomscout/advisory/RulesEngine.kt
@@ -1,0 +1,16 @@
+package com.vanta.phantomscout.advisory
+
+import com.vanta.phantomscout.data.Profile
+import com.vanta.phantomscout.data.Snapshot
+
+/** Applies policies to snapshots to suggest fixes. */
+object RulesEngine {
+    fun evaluate(s: Snapshot, p: Profile): List<FixAction> {
+        val fixes = mutableListOf<FixAction>()
+        if (p.policy == "all_radio_off") {
+            if (s.radio.wifiEnabled) fixes += FixAction("Turn off Wi-Fi")
+            if (s.radio.bleEnabled) fixes += FixAction("Turn off Bluetooth")
+        }
+        return fixes
+    }
+}

--- a/app/src/main/java/com/vanta/phantomscout/data/Profiles.kt
+++ b/app/src/main/java/com/vanta/phantomscout/data/Profiles.kt
@@ -1,0 +1,24 @@
+package com.vanta.phantomscout.data
+
+import android.content.Context
+import org.json.JSONArray
+
+/** Simple profile loaded from guardian policies. */
+data class Profile(
+    val name: String,
+    val policy: String
+)
+
+object Profiles {
+    fun load(ctx: Context): List<Profile> {
+        val arr = ctx.assets.open("guardian_policies.json").use { input ->
+            JSONArray(input.bufferedReader().use { it.readText() })
+        }
+        val items = mutableListOf<Profile>()
+        for (i in 0 until arr.length()) {
+            val o = arr.getJSONObject(i)
+            items += Profile(o.getString("name"), o.getString("policy"))
+        }
+        return items
+    }
+}

--- a/app/src/main/java/com/vanta/phantomscout/sensing/self/SelfTelemetry.kt
+++ b/app/src/main/java/com/vanta/phantomscout/sensing/self/SelfTelemetry.kt
@@ -1,0 +1,22 @@
+package com.vanta.phantomscout.sensing.self
+
+import android.content.Context
+import android.os.BatteryManager
+import android.os.Build
+import android.os.SystemClock
+
+/** Basic device telemetry snapshot. */
+data class SelfTelemetry(
+    val uptimeMs: Long,
+    val batteryPct: Int,
+    val model: String = Build.MODEL
+) {
+    companion object {
+        fun read(ctx: Context): SelfTelemetry {
+            val bm = ctx.getSystemService(BatteryManager::class.java)
+            val level = bm?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY) ?: -1
+            val uptime = SystemClock.elapsedRealtime()
+            return SelfTelemetry(uptime, level)
+        }
+    }
+}

--- a/app/src/main/java/com/vanta/phantomscout/ui/AarFragment.kt
+++ b/app/src/main/java/com/vanta/phantomscout/ui/AarFragment.kt
@@ -1,0 +1,13 @@
+package com.vanta.phantomscout.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+
+/** After-action report generation. */
+class AarFragment : Fragment() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        // TODO: summarize logs into a report
+    }
+}

--- a/app/src/main/java/com/vanta/phantomscout/ui/LeaksFragment.kt
+++ b/app/src/main/java/com/vanta/phantomscout/ui/LeaksFragment.kt
@@ -1,0 +1,13 @@
+package com.vanta.phantomscout.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+
+/** Shows potential information leaks. */
+class LeaksFragment : Fragment() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        // TODO: list detected leaks
+    }
+}

--- a/app/src/main/java/com/vanta/phantomscout/ui/ProfilesFragment.kt
+++ b/app/src/main/java/com/vanta/phantomscout/ui/ProfilesFragment.kt
@@ -1,0 +1,15 @@
+package com.vanta.phantomscout.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import com.vanta.phantomscout.data.Profiles
+
+/** Lists guardian profiles. */
+class ProfilesFragment : Fragment() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val profiles = Profiles.load(requireContext())
+        // TODO: show profiles in UI
+    }
+}


### PR DESCRIPTION
## Summary
- add SelfTelemetry for device uptime and battery stats
- load guardian profiles from JSON and apply simple policy rules
- scaffold Leaks, Profiles, and AAR fragments for future UI work

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application', version: '8.1.1', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10b53c3008328b2720be3cb46519f