### PR TITLE
feat: persist leak-aware snapshots and AAR export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.netxml
 *.csv
 *.kml
+.gradle/

--- a/app/src/main/java/com/vanta/phantomscout/data/LogStore.kt
+++ b/app/src/main/java/com/vanta/phantomscout/data/LogStore.kt
@@ -1,17 +1,22 @@
 package com.vanta.phantomscout.data
 
 import android.content.Context
+import android.os.Environment
 import java.io.File
 import java.io.FileWriter
 import com.google.gson.Gson
 
-/** Simple CSV/JSON log writer for snapshots. */
+/**
+ * Persistent log writer. Stores compact CSV metrics alongside full
+ * JSON snapshots capturing leaks and mitigation outcomes.
+ */
 class LogStore(private val ctx: Context) {
     private val gson = Gson()
     private val dir: File = File(ctx.filesDir, "logs").apply { mkdirs() }
     private val csv = File(dir, "scan.csv")
+    private val jsonl = File(dir, "scan.jsonl")
 
-    fun appendCsv(s: Snapshot, risk: Int) {
+    fun append(s: Snapshot, risk: Int, leaks: List<String>, fixes: Map<String, Boolean>) {
         val line = listOf(
             System.currentTimeMillis(), risk,
             s.wifiCount, s.wifiMaxRssi,
@@ -19,12 +24,21 @@ class LogStore(private val ctx: Context) {
             s.radio.wifiEnabled, s.radio.bleEnabled, s.radio.nfcEnabled
         ).joinToString(",")
         FileWriter(csv, true).use { it.appendLine(line) }
+
+        val entry = AarEntry(System.currentTimeMillis(), s, leaks, fixes)
+        FileWriter(jsonl, true).use { it.appendLine(gson.toJson(entry)) }
     }
 
-    fun exportJson(): File {
-        val json = gson.toJson(csv.readLines())
-        val out = File(dir, "scan.json")
-        out.writeText(json)
+    /** Export After Action Report to /Documents/PhantomScout/Reports/. */
+    fun exportAar(): File {
+        val docs = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+        val reports = File(docs, "PhantomScout/Reports").apply { mkdirs() }
+        val out = File(reports, "aar-${System.currentTimeMillis()}.json")
+        val payload = if (jsonl.exists())
+            jsonl.readLines().joinToString(prefix = "[", postfix = "]", separator = ",")
+        else "[]"
+        out.writeText(payload)
         return out
     }
 }
+

--- a/app/src/main/java/com/vanta/phantomscout/data/Models.kt
+++ b/app/src/main/java/com/vanta/phantomscout/data/Models.kt
@@ -30,3 +30,11 @@ data class Snapshot(
     val bleMaxRssi get() = ble.maxOfOrNull { it.rssi } ?: -120
     val hiddenSsids get() = wifi.any { it.ssid.isEmpty() }
 }
+
+/** Log entry capturing full snapshot and any detected leaks/fix outcomes. */
+data class AarEntry(
+    val timestamp: Long,
+    val snapshot: Snapshot,
+    val leaks: List<String>,
+    val fixes: Map<String, Boolean>
+)

--- a/app/src/main/java/com/vanta/phantomscout/ui/LogsFragment.kt
+++ b/app/src/main/java/com/vanta/phantomscout/ui/LogsFragment.kt
@@ -16,10 +16,15 @@ class LogsFragment : Fragment() {
         store = LogStore(requireContext())
     }
 
-    fun toggleLogging(s: Snapshot, risk: Int) {
+    fun toggleLogging(
+        s: Snapshot,
+        risk: Int,
+        leaks: List<String> = emptyList(),
+        fixes: Map<String, Boolean> = emptyMap()
+    ) {
         if (!logging) logging = true
-        store.appendCsv(s, risk)
+        store.append(s, risk, leaks, fixes)
     }
 
-    fun export() = store.exportJson()
+    fun export() = store.exportAar()
 }


### PR DESCRIPTION
## Summary
- store leak-aware snapshots and mitigation outcomes as JSON lines
- export After Action Reports to `/Documents/PhantomScout/Reports`
- ignore Gradle build artifacts

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application', version: '8.1.1', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10b6ee38883288bba9111df58c403