### PR TITLE
feat: add low power BLE scan service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+logs/
+__pycache__/
+*.cap
+*.netxml
+*.csv
+*.kml

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,5 +22,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".sensing.ble.BleScanService"
+            android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/com/vanta/phantomscout/sensing/ble/BleScanService.kt
+++ b/app/src/main/java/com/vanta/phantomscout/sensing/ble/BleScanService.kt
@@ -1,0 +1,34 @@
+package com.vanta.phantomscout.sensing.ble
+
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+/** Service hosting a low power BLE scan. */
+class BleScanService : Service() {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private lateinit var scanner: BleScanner
+
+    private val binder = LocalBinder()
+
+    override fun onCreate() {
+        super.onCreate()
+        scanner = BleScanner(this, scope)
+    }
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    inner class LocalBinder : Binder() {
+        fun scanner(): BleScanner = scanner
+    }
+}

--- a/app/src/main/java/com/vanta/phantomscout/sensing/ble/BleScanner.kt
+++ b/app/src/main/java/com/vanta/phantomscout/sensing/ble/BleScanner.kt
@@ -3,19 +3,27 @@ package com.vanta.phantomscout.sensing.ble
 import android.bluetooth.le.BluetoothLeScanner
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
 import android.content.Context
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.stateIn
 import com.vanta.phantomscout.data.BleAdvert
 import com.vanta.phantomscout.util.OuiLookup
 
-/** Low power BLE scanner using callbackFlow. */
-class BleScanner(ctx: Context) {
+/** Low power BLE scanner exposing results as StateFlow. */
+class BleScanner(ctx: Context, scope: CoroutineScope) {
     private val scanner: BluetoothLeScanner? =
         (ctx.getSystemService(Context.BLUETOOTH_SERVICE) as? android.bluetooth.BluetoothManager)?.adapter?.bluetoothLeScanner
 
-    fun scanFlow(): Flow<List<BleAdvert>> = callbackFlow {
+    private val settings = ScanSettings.Builder()
+        .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+        .build()
+
+    private val _adverts: StateFlow<List<BleAdvert>> = callbackFlow {
         val found = mutableMapOf<String, BleAdvert>()
         val cb = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
@@ -23,15 +31,17 @@ class BleScanner(ctx: Context) {
                 val advert = BleAdvert(
                     address = addr,
                     rssi = result.rssi,
-                    manufacturer = result.scanRecord?.manufacturerSpecificData?.keyAt(0)
-                        ?.let { OuiLookup.vendorFor(addr) },
+                    manufacturer = OuiLookup.vendorFor(addr),
                     connectable = result.isConnectable
                 )
                 found[addr] = advert
                 trySend(found.values.toList())
             }
         }
-        scanner?.startScan(null, android.bluetooth.le.ScanSettings.Builder().setScanMode(android.bluetooth.le.ScanSettings.SCAN_MODE_LOW_POWER).build(), cb)
+        scanner?.startScan(null, settings, cb)
         awaitClose { scanner?.stopScan(cb) }
-    }
+    }.stateIn(scope, SharingStarted.Eagerly, emptyList())
+
+    /** Current set of discovered adverts. */
+    val adverts: StateFlow<List<BleAdvert>> = _adverts
 }


### PR DESCRIPTION
## Summary
- expose BLE adverts via StateFlow using low-power scanning
- add BleScanService to manage scanning lifecycle
- register BleScanService in manifest

## Testing
- `gradle assembleDebug` *(fails: Plugin [id: 'com.android.application', version: '8.1.1', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10b01d8388328abe22a8c9da51be3