### PR TITLE
fix: configure repositories for Android build

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 rootProject.name = "Phantom-Scout"
 include(":app")


### PR DESCRIPTION
## Summary
- configure plugin and dependency repositories so Gradle can resolve the Android application plugin

## Testing
- `gradle assembleDebug` *(fails: still resolving dependencies; terminated due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c10d6cfa848328a67b9026abe71619