### PR TITLE
MVP: scanners, risk dial, logs, CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,16 @@
+name: Bug
+description: Report a bug
+labels: [bug]
+body:
+  - type: textarea
+    id: repro
+    attributes: { label: Steps to reproduce }
+  - type: textarea
+    id: expected
+    attributes: { label: Expected }
+  - type: textarea
+    id: actual
+    attributes: { label: Actual }
+  - type: textarea
+    id: logs
+    attributes: { label: Logs / screenshots }

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,18 @@
+name: Feature
+description: Request a new feature
+labels: [enhancement]
+body:
+  - type: textarea
+    id: what
+    attributes: { label: What should be built?, placeholder: Clear user story + acceptance criteria }
+  - type: textarea
+    id: how
+    attributes: { label: How to implement (sketch) }
+  - type: checkboxes
+    id: ac
+    attributes:
+      label: Acceptance criteria
+      options:
+        - label: Builds locally
+        - label: Code reviewed
+        - label: Screenshots/logs attached

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What
+-
+
+## Why
+-
+
+## How to test
+1.
+2.
+
+## Screenshots / logs
+

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,28 @@
+name: Android CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "feat/mvp-scan" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+      - name: Build Debug
+        run: ./gradlew assembleDebug
+      - name: Upload APK
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: PhantomScout-debug-apk
+          path: app/build/outputs/apk/debug/*.apk

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+## Phantom Scout — Road to First APK
+
+**MVP (v0.1)**
+- [ ] Foreground ScanningService + notification
+- [ ] Runtime permission flow
+- [ ] Wi-Fi scanner (12–15s) + list UI
+- [ ] BLE scanner (low-power) + list UI
+- [ ] Risk dial (green/amber/red) with top 3 reasons
+- [ ] “My Phone” panel (Wi-Fi/BLE/NFC/UWB/Airplane settings)
+- [ ] CSV/JSON logging to /Documents/PhantomScout + Share
+
+**Signature Guardian (v0.2)**
+- [ ] SelfTelemetry (probeRate, hotspot, BLE duty, RAT)
+- [ ] Profiles (Base/Patrol/Near-OBJ)
+- [ ] Rules engine + Leaks UI + Fix actions
+- [ ] AAR report exporter

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,11 +5,11 @@
     <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 

--- a/app/src/main/assets/guardian_policies.json
+++ b/app/src/main/assets/guardian_policies.json
@@ -1,4 +1,26 @@
-[
-  {"name": "Default", "policy": "baseline"},
-  {"name": "Strict", "policy": "all_radio_off"}
-]
+{
+  "profiles": ["Base","Patrol","NearOBJ"],
+  "rules": [
+    {
+      "id": "wifi_probes_patrol",
+      "when": { "profile": "Patrol", "self.probeRatePerMin": { ">": 0 } },
+      "leak": "Wi-Fi probe requests active in Patrol",
+      "severity": "HIGH",
+      "fix": ["OPEN_WIFI_SETTINGS","SUGGEST_WIFI_OFF"]
+    },
+    {
+      "id": "ble_on_patrol",
+      "when": { "profile": "Patrol", "self.ble.on": true },
+      "leak": "Bluetooth enabled under Patrol profile",
+      "severity": "MEDIUM",
+      "fix": ["OPEN_BT_SETTINGS","SUGGEST_BT_OFF"]
+    },
+    {
+      "id": "hotspot_any",
+      "when": { "self.hotspotOn": true },
+      "leak": "Phone hotspot is broadcasting",
+      "severity": "HIGH",
+      "fix": ["OPEN_HOTSPOT_SETTINGS","SUGGEST_DISABLE_HOTSPOT"]
+    }
+  ]
+}


### PR DESCRIPTION
## What
- add Android CI workflow for debug builds
- define default guardian leak policies
- add issue and PR templates
- document roadmap checklist

## Checklist
- [ ] Foreground ScanningService + notification
- [ ] Runtime permission flow
- [ ] Wi-Fi scanner (12–15s) + list UI
- [ ] BLE scanner (low-power) + list UI
- [ ] Risk dial (green/amber/red) with top 3 reasons
- [ ] “My Phone” panel (Wi-Fi/BLE/NFC/UWB/Airplane settings)
- [ ] CSV/JSON logging to /Documents/PhantomScout + Share

## Screenshots / logs
- TBD

------
https://chatgpt.com/codex/tasks/task_e_68c1116aaac883288d9ce0d0b9a13fb8